### PR TITLE
fix application version reference for bumpversion and runtime

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.2
+current_version = 0.0.2-alpha
 commit = True
 tag = False
 message = "Bump version: {current_version} → {new_version}"
@@ -15,4 +15,4 @@ values =
 	dev
 	alpha
 
-[bumpversion:file:setup.py]
+[bumpversion:file:amazon_advertising_api/versions.py]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.2-alpha
+current_version = 0.0.2
 commit = True
 tag = False
 message = "Bump version: {current_version} → {new_version}"

--- a/amazon_advertising_api/advertising_api.py
+++ b/amazon_advertising_api/advertising_api.py
@@ -1,3 +1,5 @@
+import configparser
+
 from amazon_advertising_api.regions import regions
 from amazon_advertising_api.versions import versions
 from io import BytesIO
@@ -49,8 +51,13 @@ class AdvertisingApi(object):
         self.refresh_token = refresh_token
 
         self.api_version = versions['api_version']
+
+        config = configparser.RawConfigParser()
+        config.read('../.bumpversion.cfg')
+        self.application_version = config.get('bumpversion', 'current_version')
         self.user_agent = 'AdvertisingAPI Python Client Library v{}'.format(
-            versions['application_version'])
+            self.application_version)
+
         self.profile_id = profile_id
         self.token_url = None
 

--- a/amazon_advertising_api/advertising_api.py
+++ b/amazon_advertising_api/advertising_api.py
@@ -1,8 +1,6 @@
-import configparser
-import os
-
-from amazon_advertising_api.regions import regions
+from amazon_advertising_api import versions as v
 from amazon_advertising_api.versions import versions
+from amazon_advertising_api.regions import regions
 from io import BytesIO
 try:
     # Python 3
@@ -53,11 +51,8 @@ class AdvertisingApi(object):
 
         self.api_version = versions['api_version']
 
-        config = configparser.RawConfigParser()
-        config.read(os.path.join(os.path.dirname(__file__), '../.bumpversion.cfg'))
-        self.application_version = config.get('bumpversion', 'current_version')
         self.user_agent = 'AdvertisingAPI Python Client Library v{}'.format(
-            self.application_version)
+            v.__version__)
 
         self.profile_id = profile_id
         self.token_url = None

--- a/amazon_advertising_api/advertising_api.py
+++ b/amazon_advertising_api/advertising_api.py
@@ -1,4 +1,5 @@
 import configparser
+import os
 
 from amazon_advertising_api.regions import regions
 from amazon_advertising_api.versions import versions
@@ -53,7 +54,7 @@ class AdvertisingApi(object):
         self.api_version = versions['api_version']
 
         config = configparser.RawConfigParser()
-        config.read('../.bumpversion.cfg')
+        config.read(os.path.join(os.path.dirname(__file__), '../.bumpversion.cfg'))
         self.application_version = config.get('bumpversion', 'current_version')
         self.user_agent = 'AdvertisingAPI Python Client Library v{}'.format(
             self.application_version)

--- a/amazon_advertising_api/versions.py
+++ b/amazon_advertising_api/versions.py
@@ -1,3 +1,5 @@
+__version__ = "0.0.2-alpha"
+
 versions = {
     'api_version': 'v2',
     'api_version_sb': 'v3'}

--- a/amazon_advertising_api/versions.py
+++ b/amazon_advertising_api/versions.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.2-alpha"
+__version__ = "0.0.2"
 
 versions = {
     'api_version': 'v2',

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 from setuptools import setup
 
+from amazon_advertising_api import versions
 
 setup(
     name='amazon_advertising_api',
     packages=['amazon_advertising_api'],
-    version='0.0.2',
+    version=versions.__version__,
     description='Unofficial Amazon Sponsored Products Python client library.',
     url='https://github.com/pepsico-ecommerce/amazon-advertising-api-python')


### PR DESCRIPTION
Set up module version variable in a way that works both for bumpversion lib (Used on CI) and available on runtime.