### PR TITLE
FIX: Response to data in response handling

### DIFF
--- a/amazon_advertising_api/advertising_api.py
+++ b/amazon_advertising_api/advertising_api.py
@@ -1043,10 +1043,7 @@ class AdvertisingApi(object):
         :POST: /snapshots
 
         Required data:
-        * :campaignType: The type of campaign for which snapshot should be
-          generated. Must be one of 'sponsoredProducts' or 'headlineSearch'
-          Defaults to 'sponsoredProducts.
-          :campaign_type: Should be 'hsa' or 'sp'
+        * :campaign_type: Should be 'hsa' or 'sp'
         """
         if record_type is not None:
             interface = '{}/{}/snapshot'.format(campaign_type, record_type)

--- a/amazon_advertising_api/advertising_api.py
+++ b/amazon_advertising_api/advertising_api.py
@@ -1079,7 +1079,7 @@ class AdvertisingApi(object):
         interface = 'reports/{}'.format(report_id)
         res = self._operation(interface)
         if res['success']:
-            body = json.loads(res['data'])
+            body = json.loads(res['response'])
             if body.get('status') == 'SUCCESS':
                 res = self._download(location=body['location'])
         return res
@@ -1087,9 +1087,9 @@ class AdvertisingApi(object):
     def get_snapshot(self, snapshot_id):
         interface = 'snapshots/{}'.format(snapshot_id)
         res = self._operation(interface)
-        if json.loads(res['data'])['status'] == 'SUCCESS':
+        if json.loads(res['response'])['status'] == 'SUCCESS':
             res = self._download(
-                location=json.loads(res['data'])['location'])
+                location=json.loads(res['response'])['location'])
             return res
         else:
             return res
@@ -1211,7 +1211,7 @@ class AdvertisingApi(object):
                 'success': True,
                 'api_version': self.api_version if not api_v3 else versions['api_version_sb'],
                 'code': f.code,
-                'data': f.read().decode('utf-8')}
+                'response': f.read().decode('utf-8')}
 
         except urllib.error.HTTPError as e:
             return {'success': False,

--- a/amazon_advertising_api/advertising_api.py
+++ b/amazon_advertising_api/advertising_api.py
@@ -1048,11 +1048,6 @@ class AdvertisingApi(object):
           Defaults to 'sponsoredProducts.
           :campaign_type: Should be 'hsa' or 'sp'
         """
-        if not data:
-            data = {'campaignType': 'sponsoredProducts'}
-        elif not data.get('campaignType'):
-            data['campaignType'] = 'sponsoredProducts'
-
         if record_type is not None:
             interface = '{}/{}/snapshot'.format(campaign_type, record_type)
             return self._operation(interface, data, method='POST')

--- a/amazon_advertising_api/advertising_api.py
+++ b/amazon_advertising_api/advertising_api.py
@@ -1087,7 +1087,7 @@ class AdvertisingApi(object):
         interface = 'reports/{}'.format(report_id)
         res = self._operation(interface)
         if res['success']:
-            body = json.loads(res['response'])
+            body = json.loads(res['data'])
             if body.get('status') == 'SUCCESS':
                 res = self._download(location=body['location'])
         return res
@@ -1095,9 +1095,9 @@ class AdvertisingApi(object):
     def get_snapshot(self, snapshot_id):
         interface = 'snapshots/{}'.format(snapshot_id)
         res = self._operation(interface)
-        if json.loads(res['response'])['status'] == 'SUCCESS':
+        if json.loads(res['data'])['status'] == 'SUCCESS':
             res = self._download(
-                location=json.loads(res['response'])['location'])
+                location=json.loads(res['data'])['location'])
             return res
         else:
             return res


### PR DESCRIPTION
Since now we return data in the following format 
```
{'success': True,
'api_version': ,
'code': ,
'data':} 
```
it is required to parse the `data` field instead of `response`