### PR TITLE
revert response param rename and fix snapshot endpoint

### DIFF
--- a/amazon_advertising_api/advertising_api.py
+++ b/amazon_advertising_api/advertising_api.py
@@ -1043,16 +1043,8 @@ class AdvertisingApi(object):
         :POST: /snapshots
 
         Required data:
-        * :campaignType: The type of campaign for which snapshot should be
-          generated. Must be one of 'sponsoredProducts' or 'headlineSearch'
-          Defaults to 'sponsoredProducts.
           :campaign_type: Should be 'hsa' or 'sp'
         """
-        if not data:
-            data = {'campaignType': 'sponsoredProducts'}
-        elif not data.get('campaignType'):
-            data['campaignType'] = 'sponsoredProducts'
-
         if record_type is not None:
             interface = '{}/{}/snapshot'.format(campaign_type, record_type)
             return self._operation(interface, data, method='POST')
@@ -1219,7 +1211,7 @@ class AdvertisingApi(object):
                 'success': True,
                 'api_version': self.api_version if not api_v3 else versions['api_version_sb'],
                 'code': f.code,
-                'data': f.read().decode('utf-8')}
+                'response': f.read().decode('utf-8')}
 
         except urllib.error.HTTPError as e:
             return {'success': False,

--- a/amazon_advertising_api/advertising_api.py
+++ b/amazon_advertising_api/advertising_api.py
@@ -1139,6 +1139,7 @@ class AdvertisingApi(object):
                     data = f.read()
                     return {'success': True,
                             'code': res.code,
+                            'api_version': versions["api_version"],
                             'response': json.loads(data.decode('utf-8'))}
                 else:
                     return {'success': False,

--- a/amazon_advertising_api/advertising_api.py
+++ b/amazon_advertising_api/advertising_api.py
@@ -1216,6 +1216,7 @@ class AdvertisingApi(object):
 
         except urllib.error.HTTPError as e:
             return {'success': False,
+                    'api_version': self.api_version if not api_v3 else versions['api_version_sb'],
                     'code': e.code,
                     'response': '{msg}: {details}'.format(msg=e.msg, details=e.read())}
 


### PR DESCRIPTION
- `response` param seem to be set in many places within the client, thus I revert renaming from base method. We are going to handle that in one place on airflow_dag side
- snapshot request endpoint doesn't work with the payload being passed in a client. Error message: `Campaign type is not supported in snapshot request.`